### PR TITLE
extract selenium install logic to a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,21 +232,6 @@ module.exports = {
     }
   }
 }
-/**
- * selenium-download does exactly what it's name suggests;
- * downloads (or updates) the version of Selenium (& chromedriver)
- * on your localhost where it will be used by Nightwatch.
- /the following code checks for the existence of `selenium.jar` before trying to run our tests.
- */
-
-require('fs').stat(BINPATH + 'selenium.jar', function (err, stat) { // got it?
-  if (err || !stat || stat.size < 1) {
-    require('selenium-download').ensure(BINPATH, function(error) {
-      if (error) throw new Error(error); // no point continuing so exit!
-      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
-    });
-  }
-});
 
 function padLeft (count) { // theregister.co.uk/2016/03/23/npm_left_pad_chaos/
   return count < 10 ? '0' + count : count.toString();
@@ -282,12 +267,45 @@ We have a slightly more _evolved_ `nightwatch.conf.js` (_with Saucelabs_) see:
 [github.com/dwyl/learn-nightwatch/**nightwatch.conf.js**](https://github.com/dwyl/learn-nightwatch/blob/master/nightwatch.conf.js)
 
 
-### 7) Running config file
+### 7) Installing Selenium
 
-You will need to run the config file you created to download the Selenium driver.
+Thanks to [selenium-download](https://github.com/groupon/selenium-download) we can download and install a selenium instance locally in our project. We have this small javaScript to download and install selenium:
+
+`install-selenium.js`
+```js
+const BINPATH = require('./constants').BINPATH;
+
+/**
+ * selenium-download does exactly what it's name suggests;
+ * downloads (or updates) the version of Selenium (& chromedriver)
+ * on your localhost where it will be used by Nightwatch.
+ */
+require('fs').stat(BINPATH + 'selenium.jar', function (err, stat) { // got it?
+  if (err || !stat || stat.size < 1) {
+    require('selenium-download').ensure(BINPATH, function(error) {
+      if (error) throw new Error(error); // no point continuing so exit!
+      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
+    });
+  }
+});
+```
+
+You can copy it and just call it to install selenium locally to your `BINPATH`:
 
 ```sh
-node nightwatch.conf.BASIC.js
+node install-selenium.js
+```
+
+Also, by setting such a command as a `postinstall` hook in your `package.json`, you can ensure that selenium is installed after an `npm install` call:
+
+```js
+
+"scripts": {
+  "postinstall": "node install-selenium.js",
+  
+  ...
+  
+},
 ```
 
 ### 8) Create Your Nightwatch Test

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,7 @@
+const CONSTANTS = {};
+
+CONSTANTS.PKG = require('./package.json');// so we can get the version of the project
+CONSTANTS.BINPATH = './node_modules/nightwatch/bin/'; // change if required
+CONSTANTS.SCREENSHOT_PATH = "./node_modules/nightwatch/screenshots/" + CONSTANTS.PKG.version + "/";
+
+module.exports = CONSTANTS;

--- a/install-selenium.js
+++ b/install-selenium.js
@@ -1,0 +1,15 @@
+const BINPATH = require('./constants').BINPATH;
+
+/**
+ * selenium-download does exactly what it's name suggests;
+ * downloads (or updates) the version of Selenium (& chromedriver)
+ * on your localhost where it will be used by Nightwatch.
+ */
+require('fs').stat(BINPATH + 'selenium.jar', function (err, stat) { // got it?
+  if (err || !stat || stat.size < 1) {
+    require('selenium-download').ensure(BINPATH, function(error) {
+      if (error) throw new Error(error); // no point continuing so exit!
+      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
+    });
+  }
+});

--- a/nightwatch.conf.BASIC.js
+++ b/nightwatch.conf.BASIC.js
@@ -1,6 +1,10 @@
 require('env2')('.env'); // optionally store youre Evironment Variables in .env
-const SCREENSHOT_PATH = "./screenshots/";
-const BINPATH = './node_modules/nightwatch/bin/';
+
+const CONSTANTS = require('./constants');
+
+const PKG = CONSTANTS.PKG; // so we can get the version of the project
+const BINPATH = CONSTANTS.BINPATH // change if required.
+const SCREENSHOT_PATH = CONSTANTS.SCREENSHOT_PATH;
 
 // we use a nightwatch.conf.js file so we can include comments and helper functions
 module.exports = {
@@ -38,23 +42,6 @@ module.exports = {
     }
   }
 }
-
-/**
- * selenium-download does exactly what it's name suggests;
- * downloads (or updates) the version of Selenium (& chromedriver)
- * on your localhost where it will be used by Nightwatch.
- /the following code checks for the existence of `selenium.jar` before trying to run our tests.
- */
-
-require('fs').stat(BINPATH + 'selenium.jar', function (err, stat) { // got it?
-  if (err || !stat || stat.size < 1) {
-    require('selenium-download').ensure(BINPATH, function(error) {
-      if (error) throw new Error(error); // no point continuing so exit!
-      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
-    });
-  }
-});
-
 
 function padLeft (count) { // theregister.co.uk/2016/03/23/npm_left_pad_chaos/
   return count < 10 ? '0' + count : count.toString();

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,7 +1,11 @@
 require('env2')('.env'); // optionally store your environment variables in .env
-const PKG = require('./package.json'); // so we can get the version of the project
-const BINPATH = './node_modules/nightwatch/bin/'; // change if required.
-const SCREENSHOT_PATH = "./node_modules/nightwatch/screenshots/" + PKG.version + "/";
+
+const CONSTANTS = require('./constants');
+
+const PKG = CONSTANTS.PKG; // so we can get the version of the project
+const BINPATH = CONSTANTS.BINPATH // change if required.
+const SCREENSHOT_PATH = CONSTANTS.SCREENSHOT_PATH;
+
 
 const config = { // we use a nightwatch.conf.js file so we can include comments and helper functions
   "src_folders": [
@@ -116,19 +120,7 @@ const config = { // we use a nightwatch.conf.js file so we can include comments 
 }
 module.exports = config;
 
-/**
- * selenium-download does exactly what it's name suggests;
- * downloads (or updates) the version of Selenium (& chromedriver)
- * on your localhost where it will be used by Nightwatch.
- */
-require('fs').stat(BINPATH + 'selenium.jar', function (err, stat) { // got it?
-  if (err || !stat || stat.size < 1) {
-    require('selenium-download').ensure(BINPATH, function(error) {
-      if (error) throw new Error(error); // no point continuing so exit!
-      console.log('✔ Selenium & Chromedriver downloaded to:', BINPATH);
-    });
-  }
-});
+
 
 function padLeft (count) { // theregister.co.uk/2016/03/23/npm_left_pad_chaos/
   return count < 10 ? '0' + count : count.toString();

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": "4.4.6"
   },
   "scripts": {
-    "postinstall": "node nightwatch.conf.js",
+    "postinstall": "node install-selenium.js",
     "test": "./node_modules/.bin/nightwatch --env local",
     "ie": "./node_modules/.bin/nightwatch -e ie11",
     "sauce": "./node_modules/.bin/nightwatch -e chrome,ie11,android_s4_emulator,iphone_6_simulator",


### PR DESCRIPTION
Before all: thanks you for this cool repo. It helped me a lot configuring nightwatch in a real project 👍 

Currently, the whole `nightwatch.conf.js` is set as a `postinstall` hook in `package.json`. But the only reason to do that -as far as I understand- is to ensure that selenium gets downloaded. This is pretty misleading since people just copypasting the configuration object from `nightwatch.conf.js` to their own config file as a template would not get the tests to run, since selenium would not be downloaded.

Also, this way is just more clear what the `postinstall` hook is about.

Since now both the config files and the `selenium-install.js` module need the `BINPATH`, constants were also refactored to a common module.