### PR TITLE
simplify package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "node": "4.4.6"
   },
   "scripts": {
-    "test": "./node_modules/.bin/nightwatch --env local",
-    "ie": "./node_modules/.bin/nightwatch -e ie11",
-    "sauce": "./node_modules/.bin/nightwatch -e chrome,ie11,android_s4_emulator,iphone_6_simulator",
+    "test": "nightwatch --env local",
+    "ie": "nightwatch -e ie11",
+    "sauce": "nightwatch -e chrome,ie11,android_s4_emulator,iphone_6_simulator",
     "upload": "node test/e2e/upload_screenshots_to_s3.js",
     "e2e": "npm run sauce; npm run upload",
-    "dev": "./node_modules/.bin/nodemon -w test/index.html --delay 250ms --exec 'npm run upload'"
+    "dev": "nodemon -w test/index.html --delay 250ms --exec 'npm run upload'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
"In addition to the shell's pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix. "

-https://docs.npmjs.com/cli/run-script